### PR TITLE
Use `router.original` to hide path from OpenAPI schema

### DIFF
--- a/examples/anime-adventure/src/index.ts
+++ b/examples/anime-adventure/src/index.ts
@@ -24,7 +24,7 @@ const router = OpenAPIRouter({
 router.get('/start', routes.StartGame)
 router.get('/continue', routes.ContinueGame)
 
-router.get('/.well-known/ai-plugin.json', (request: Request) => {
+router.original.get('/.well-known/ai-plugin.json', (request: Request) => {
   const host = request.headers.get('host')
   const pluginManifest = defineAIPluginManifest(
     {

--- a/examples/ascii-art/src/index.ts
+++ b/examples/ascii-art/src/index.ts
@@ -14,7 +14,7 @@ const router = OpenAPIRouter({
 
 router.get('/render', routes.ASCIIArtRender)
 
-router.get('/.well-known/ai-plugin.json', (request: Request) => {
+router.original.get('/.well-known/ai-plugin.json', (request: Request) => {
   const host = request.headers.get('host')
   const pluginManifest = defineAIPluginManifest({
     schema_version: 'v1',

--- a/examples/dexa-lex-fridman/src/index.ts
+++ b/examples/dexa-lex-fridman/src/index.ts
@@ -19,7 +19,7 @@ const router = OpenAPIRouter({
 
 router.get('/search', routes.DexaSearch)
 
-router.get('/.well-known/ai-plugin.json', (request: Request) => {
+router.original.get('/.well-known/ai-plugin.json', (request: Request) => {
   const host = request.headers.get('host')
   const pluginManifest = defineAIPluginManifest(
     {

--- a/examples/dexa-mfm/src/index.ts
+++ b/examples/dexa-mfm/src/index.ts
@@ -20,7 +20,7 @@ const router = OpenAPIRouter({
 
 router.get('/search', routes.DexaSearch)
 
-router.get('/.well-known/ai-plugin.json', (request: Request) => {
+router.original.get('/.well-known/ai-plugin.json', (request: Request) => {
   const host = request.headers.get('host')
   const pluginManifest = defineAIPluginManifest(
     {

--- a/examples/talk-to-books/src/index.ts
+++ b/examples/talk-to-books/src/index.ts
@@ -20,7 +20,7 @@ const router = OpenAPIRouter({
 
 router.get('/search', routes.BookSearch)
 
-router.get('/.well-known/ai-plugin.json', (request: Request) => {
+router.original.get('/.well-known/ai-plugin.json', (request: Request) => {
   const host = request.headers.get('host')
   const pluginManifest = defineAIPluginManifest(
     {


### PR DESCRIPTION
See https://github.com/cloudflare/itty-router-openapi/tree/main#5-hiding-routes-in-the-openapi-schema